### PR TITLE
Configurable logical paths/mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ this plugin. Order matters.
   Default: `[]`
   - `test`: Regex for matching source files using their absolute paths. 
   - `logicalPath`: Pattern using Webpack placeholders for renaming the logical
-    path. Note: `[path]` requires a context (see next).
+    path.
   - `context`: *Absolute* path to a context directory for the sources matched
     by this mapping. Use in combination with the `[path]` placeholder in
     `logicalPath` to create logical paths relative to an arbitrary directory.
+    Default: `sourceAssetsPath`
 - `saveAs`: *Absolute* path to where to save the output to.
   Default: `path.join(process.cwd(), 'build', 'sprockets-manifest.json')`
 - `write`: Boolean option, of whether to write the stats file or not.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ var config = {
       ignore: (/\.(gz|html)$/i),
       outputAssetsPath: path.join(__dirname, 'build', 'assets'),
       sourceAssetsPath: path.join(__dirname, 'src', 'assets'),
+      mappings: [
+        {
+          test: 'src\/assets\/images',
+          logicalPath: '[path][name].[ext]',
+          context: path.join(process.cwd(), 'src', 'assets', 'images')
+        },
+        {
+          test: 'src\/assets\/videos',
+          logicalPath: '[path][name].[ext]',
+          context: path.join(process.cwd(), 'src', 'assets', 'videos')
+        }
+      ],
       saveAs: path.join(__dirname, 'build', 'sprockets-manifest.json'),
       write: true,
       resultsKey: '__RESULTS_SPROCKETS'
@@ -65,6 +77,16 @@ this plugin. Order matters.
 - `sourceAssetsPath`: *Absolute* path to where the source assets are located.
   Helps the plugin build mappings to files like `images/picture.jpeg`.
   Default: `path.join(process.cwd(), 'src', 'assets')`.
+- `mappings`: (Optional) Array of mapping objects for customizing the logical
+  path. Note: If you provide mappings, a source file will be included in the
+  manifest only if its absolute path matches a regex in one of the mappings. 
+  Default: `[]`
+  - `test`: Regex for matching source files using their absolute paths. 
+  - `logicalPath`: Pattern using Webpack placeholders for renaming the logical
+    path. Note: `[path]` requires a context (see next).
+  - `context`: *Absolute* path to a context directory for the sources matched
+    by this mapping. Use in combination with the `[path]` placeholder in
+    `logicalPath` to create logical paths relative to an arbitrary directory.
 - `saveAs`: *Absolute* path to where to save the output to.
   Default: `path.join(process.cwd(), 'build', 'sprockets-manifest.json')`
 - `write`: Boolean option, of whether to write the stats file or not.

--- a/index.js
+++ b/index.js
@@ -84,7 +84,14 @@ SprocketsStatsWebpackPlugin.prototype.apply = function(compiler) {
           var match = mod.userRequest.match(re);
 
           if(match) {
-            logicalPath = loaderUtils.interpolateName(loaderContextStub, mapping.logicalPath, {context: mapping.context || sourceAssetsPath});
+            logicalPath = loaderUtils.interpolateName(
+              loaderContextStub,
+              mapping.logicalPath,
+              {
+                context: mapping.context || sourceAssetsPath,
+                content: mod.assets[filename]._value
+              }
+            );
             break;
           }
         }

--- a/index.js
+++ b/index.js
@@ -82,24 +82,6 @@ SprocketsStatsWebpackPlugin.prototype.apply = function(compiler) {
     var walker = walk.walk(outputAssetsPath);
     var assets = stats.toJson().assets;
 
-    assets.forEach(function(asset) {
-      var hashedAssetName = asset.name;
-      var assetName;
-      var assetExt;
-      var filename;
-
-      if ((asset.chunks && asset.chunks.length > 0) &&
-          (asset.chunkNames && asset.chunkNames.length > 0)
-      ) {
-        assetName = asset.chunkNames.slice(-1)[0];
-        assetExt = hashedAssetName.split('.').pop();
-
-        filename = assetName + '.' + assetExt;
-
-        sprockets[hashedAssetName].logical_path = filename;
-      }
-    });
-
     walker.on('file', function(rootPath, fileStat, next) {
       var fullPath = path.join(rootPath, fileStat.name);
       var filename = (path.relative(outputPath, fullPath));

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
+    "loader-utils": "^0.2.15",
     "lodash.merge": "^4.4.0",
     "walk": "^2.3.9",
     "webpack-custom-stats-patch": "^0.3.0"


### PR DESCRIPTION
I've extended the plugin to accept a `mappings` array in the configuration that allows for a flexible way to rename logical paths:
- For each asset, first we test its absolute file name against a `test` regex. If it matches, we can proceed with transforming the logical name according to a rule.
- The `logicalPath` rule uses Webpack's standard placeholders like `[name]` and `[path]`, which in this case operate on the file and path name of the asset's source file (as opposed to its emitted/fingerprinted version).
- When using the `[path]` placeholder, we can provide a `context`. The resulting `[path]` will be relative to the context path.

My change also has the side effect of allowing the user to exclude certain assets from the manifest. If a source file's absolute path doesn't match any regex, its asset won't be included.

Finally, the new mappings array is optional. If you don't include it, the plugin defaults to the current behavior.

Fixes #5.
